### PR TITLE
fix: valis volume env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,7 @@ dist
 # ignore code directories
 zora/zora
 valis/valis
+package-lock.json
+package.json
+package.json
+env_vars.sh

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -10,8 +10,8 @@ services:
     ports:
       - 8000:8000
     volumes:
-      - ${VALIS_SOCKET_DIR:-/tmp/valis}:/tmp/valis # (host_socket_dir:container_socket_dir)
-      - ${SAS_BASE_DIR}:/root/sas  # mount the local SDSS SAS
+      - ${VALIS_SOCKET_DIR:-/tmp/valis}/:/tmp/valis # (host_socket_dir:container_socket_dir)
+      - ${SAS_BASE_DIR}/:/root/sas  # mount the local SDSS SAS
       - ./valis/valis:/tmp  # mount the code dir
       - $HOME/.pgpass:/root/.pgpass  # mount the local .pgpass file
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,8 @@ services:
     ports:
       - 8000:8000
     volumes:
-      - ${VALIS_SOCKET_DIR:-/tmp/valis}:/tmp/valis # (host_socket_dir:container_socket_dir)
-      - ${SAS_BASE_DIR}:/root/sas
+      - ${VALIS_SOCKET_DIR:-/tmp/valis}/:/tmp/valis # (host_socket_dir:container_socket_dir)
+      - ${SAS_BASE_DIR}/:/root/sas
     networks:
       - valisnet
 


### PR DESCRIPTION
Fixes #1 

- fix is from [https://stackoverflow.com/questions/59904878/docker-compose-volume-name-is-too-short-names-should-be-at-least-two-alphanume](url)
- volumes were changed to: `${PWD}**/**:[rest of it]`
- changed for both production and development versions of `docker-compose.yml`
- changed .gitignore to ignore `poetry` lock files

I think occurs when the environment variables aren't set. For the testing I ran, neither environment variable used for the volume setup was set.