### PR TITLE
Adding build-essential package

### DIFF
--- a/valis/Dockerfile.dev
+++ b/valis/Dockerfile.dev
@@ -7,6 +7,13 @@ WORKDIR /tmp
 # Copy project files over
 COPY ./valis/pyproject.toml ./valis/poetry.lock ./
 
+# Install build-essential package
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install Poetry
 RUN pip install poetry
 RUN poetry config virtualenvs.create false


### PR DESCRIPTION
`valis` image has been failing on installing on of the dependencies (`psutil`) which requires `gcc` to build. Surprisingly, `gcc` was not included in the base image. Installation of `build-essential` solves the problem.

I am on an Apple M1 Pro with Ventura, running Docker version 23.0.5.